### PR TITLE
Update 'Browser compatibility' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,10 +752,10 @@ how it works.
 
 ## Browser compatibility
 
-- Chromium based browsers (v80+)
+- Chromium based browsers (v84+)
 - Firefox (v90+)
-- Safari (v14.1+)
-- Opera (v67+)
+- Safari (v15+)
+- Opera (v70+)
 
 ## License & Contributors
 


### PR DESCRIPTION
Swayer doesn't work on Safari < 15, Chrome < 84, Firefox < 90, Opera < 70

Error message:
> SyntaxError: Unexpected private name #bindEvent. Cannot parse class method with private name.
