### PR TITLE
error handling with one class

### DIFF
--- a/examples/todo-app/package-lock.json
+++ b/examples/todo-app/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "todo-app",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/lib/channels.js
+++ b/lib/channels.js
@@ -1,4 +1,4 @@
-import { UnscopedChannelError } from './errors.js';
+import { SwayerError } from './errors.js';
 
 class EventEmitter {
   #events = new Map();
@@ -134,6 +134,6 @@ export default class ChannelManager {
   #getDefaultUrl() {
     const { tag, meta } = this.#context;
     if (meta?.url) return meta.url;
-    throw new UnscopedChannelError(tag);
+    throw new SwayerError('UnscopedChannelError', tag);
   }
 }

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,5 +1,5 @@
 import ElementBinding from './element.js';
-import { BadInputSchemaError } from './errors.js';
+import { SwayerError } from './errors.js';
 import { ComponentChildren, Component } from './component.js';
 import Styler from './styler.js';
 
@@ -30,7 +30,7 @@ class ComponentFactory {
       else module = ComponentFactory.moduleCache[url] = await import(url);
       return module.default(args);
     }
-    throw new BadInputSchemaError(input);
+    throw new SwayerError('BadInputSchemaError', input);
   }
 
   async createComponent(schema, parent, elementBinding) {

--- a/lib/element.js
+++ b/lib/element.js
@@ -1,4 +1,4 @@
-import { BadRootSchemaError } from './errors.js';
+import { SwayerError } from './errors.js';
 
 export default class ElementBinding {
   static id = 0;
@@ -170,7 +170,7 @@ export default class ElementBinding {
 
   setRoot() {
     const tag = this.#schema.tag;
-    if (tag !== 'html') throw new BadRootSchemaError(tag);
+    if (tag !== 'html') throw new SwayerError('BadRootSchemaError', tag);
     const root = this.#webApi.document.documentElement;
     if (root) return root.replaceWith(this.#element);
     this.#webApi.document.append(this.#element);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,14 +1,16 @@
 const ERRORS = {
   BadRootSchemaError: (tag) => `Root schema is not html, got ${tag}`,
- 
+
   BadInputSchemaError: (input) => {
     const json = JSON.stringify(input);
     return `No tag or path found, got ${json}`;
   },
- 
-  UnscopedChannelError: (tag) => `You must provide meta ({ tag: '${tag}', meta: import.meta })
+
+  UnscopedChannelError: (
+    tag
+  ) => `You must provide meta ({ tag: '${tag}', meta: import.meta })
   component property to use channels intercomponent communication`,
-}
+};
 export class SwayerError extends Error {
   constructor(message = '', context = null) {
     const fullMessage = ERRORS[message] ? ERRORS[message](context) : message;

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,7 +1,18 @@
+const ERRORS = {
+  BadRootSchemaError: (tag) => `Root schema is not html, got ${tag}`,
+ 
+  BadInputSchemaError: (input) => {
+    const json = JSON.stringify(input);
+    return `No tag or path found, got ${json}`;
+  },
+ 
+  UnscopedChannelError: (tag) => `You must provide meta ({ tag: '${tag}', meta: import.meta })
+  component property to use channels intercomponent communication`,
+}
 export class SwayerError extends Error {
-  constructor(message, name = 'SwayerError') {
-    super(message);
-    this.name = name;
+  constructor(message = '', context = null) {
+    const fullMessage = ERRORS[message] ? ERRORS[message](context) : message;
+    super(fullMessage);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swayer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swayer",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.5.0",


### PR DESCRIPTION
This is to illustrate an idea how to replace multiple error classes with one `SwayerError`
@rohiievych If you are OK with that, you can use this as an example for real changes.

Please don't merge

- [ ] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [ ] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
